### PR TITLE
Do not send preedit when closing Maliit Keyboard

### DIFF
--- a/maliit-keyboard/view/abstracttexteditor.cpp
+++ b/maliit-keyboard/view/abstracttexteditor.cpp
@@ -576,10 +576,17 @@ void AbstractTextEditor::replaceAndCommitPreedit(const QString &replacement)
     }
 }
 
-//! \brief Clears preedit.
+//! \brief Clears preedit. Does *not* update preedit in application, use replacePreedit instead.
 void AbstractTextEditor::clearPreedit()
 {
-    replacePreedit("");
+    Q_D(AbstractTextEditor);
+
+    if (not d->valid()) {
+        return;
+    }
+
+    d->text->setPreedit("");
+    d->word_engine->computeCandidates(d->text.data());
 }
 
 //! \brief Returns whether preedit functionality is enabled.


### PR DESCRIPTION
It's wrong to send preedit on reset/close, it's the framework's or input
context's responsibility to handle preedit correctly when focus is lost.
