### PR TITLE
Create a new view abstraction for Maliit Keyboard

### DIFF
--- a/maliit-keyboard/plugin/canvas.cpp
+++ b/maliit-keyboard/plugin/canvas.cpp
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Maliit Plugins
+ *
+ * Copyright (C) 2013 Michael Hasselmann
+ *
+ * Contact: maliit-discuss@lists.maliit.org
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "canvas.h"
+
+namespace MaliitKeyboard {
+class CanvasPrivate
+{};
+
+Canvas::Canvas(MAbstractInputMethodHost *host,
+               QObject *parent)
+    : View(host, parent)
+    , d_ptr(new CanvasPrivate)
+{
+    Q_UNUSED(host)
+}
+
+Canvas::~Canvas() {}
+
+QQmlContext * Canvas::context() const {return 0;}
+QQmlContext * Canvas::extendedKeysContext() const {return 0;}
+QQmlContext * Canvas::magnifierContext() const {return 0;}
+
+void Canvas::show() {}
+void Canvas::hide() {}
+
+void Canvas::showExtendedKeys() {}
+void Canvas::hideExtendedKeys() {}
+
+void Canvas::showMagnifier() {}
+void Canvas::hideMagnifier() {}
+
+void Canvas::setWidth(int width) {Q_UNUSED(width)}
+void Canvas::setHeight(int height) {Q_UNUSED(height)}
+void Canvas::setOrigin(const QPoint &origin) {Q_UNUSED(origin)}
+
+void Canvas::setExtendedKeysWidth(int width) {Q_UNUSED(width)}
+void Canvas::setExtendedKeysHeight(int height) {Q_UNUSED(height)}
+void Canvas::setExtendedKeysOrigin(const QPoint &origin) {Q_UNUSED(origin)};
+
+void Canvas::setMagnifierWidth(int width) {Q_UNUSED(width)}
+void Canvas::setMagnifierHeight(int height) {Q_UNUSED(height)}
+void Canvas::setMagnifierOrigin(const QPoint &origin) {Q_UNUSED(origin)}
+} // namespace MaliitKeyboard

--- a/maliit-keyboard/plugin/canvas.h
+++ b/maliit-keyboard/plugin/canvas.h
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Maliit Plugins
+ *
+ * Copyright (C) 2013 Michael Hasselmann
+ *
+ * Contact: maliit-discuss@lists.maliit.org
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef MALIIT_KEYBOARD_CANVAS_H
+#define MALIIT_KEYBOARD_CANVAS_H
+
+#include "view.h"
+
+namespace MaliitKeyboard {
+
+class CanvasPrivate;
+
+class Canvas
+    : public View
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(Canvas)
+    Q_DECLARE_PRIVATE(Canvas)
+
+public:
+    explicit Canvas(MAbstractInputMethodHost *host,
+                    QObject *parent = 0);
+    virtual ~Canvas();
+
+    virtual QQmlContext * context() const;
+    virtual QQmlContext * extendedKeysContext() const;
+    virtual QQmlContext * magnifierContext() const;
+
+    virtual void show();
+    virtual void hide();
+
+    virtual void showExtendedKeys();
+    virtual void hideExtendedKeys();
+
+    virtual void showMagnifier();
+    virtual void hideMagnifier();
+
+    virtual void setWidth(int width);
+    virtual void setHeight(int height);
+    virtual void setOrigin(const QPoint &origin);
+
+    virtual void setExtendedKeysWidth(int width);
+    virtual void setExtendedKeysHeight(int height);
+    virtual void setExtendedKeysOrigin(const QPoint &origin);
+
+    virtual void setMagnifierWidth(int width);
+    virtual void setMagnifierHeight(int height);
+    virtual void setMagnifierOrigin(const QPoint &origin);
+
+private:
+    const QScopedPointer<CanvasPrivate> d_ptr;
+};
+
+} // namespace MaliitKeyboard
+
+#endif // MALIIT_KEYBOARD_CANVAS_H

--- a/maliit-keyboard/plugin/plugin.pro
+++ b/maliit-keyboard/plugin/plugin.pro
@@ -25,6 +25,9 @@ HEADERS += \
     editor.h \
     updatenotifier.h \
     maliitcontext.h \
+    view.h \
+    canvas.h \
+    surfaces.h \
 
 SOURCES += \
     plugin.cpp \
@@ -32,6 +35,9 @@ SOURCES += \
     editor.cpp \
     updatenotifier.cpp \
     maliitcontext.cpp \
+    view.cpp \
+    canvas.cpp \
+    surfaces.cpp \
 
 target.path += $${MALIIT_PLUGINS_DIR}
 INSTALLS += target

--- a/maliit-keyboard/plugin/surfaces.cpp
+++ b/maliit-keyboard/plugin/surfaces.cpp
@@ -1,0 +1,257 @@
+/*
+ * This file is part of Maliit Plugins
+ *
+ * Copyright (C) 2013 Michael Hasselmann
+ *
+ * Contact: maliit-discuss@lists.maliit.org
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "surfaces.h"
+
+namespace MaliitKeyboard {
+
+
+void makeQuickViewTransparent(QQuickView *view)
+{
+    QSurfaceFormat format;
+    format.setAlphaBufferSize(8);
+    view->setFormat(format);
+    view->setColor(QColor(Qt::transparent));
+}
+
+
+QQuickView *getSurface (MAbstractInputMethodHost *host)
+{
+    QScopedPointer<QQuickView> view(new QQuickView (0));
+    host->registerWindow (view.data(), Maliit::PositionCenterBottom);
+    makeQuickViewTransparent(view.data());
+
+    return view.take ();
+}
+
+QQuickView *getOverlaySurface (MAbstractInputMethodHost *host, QQuickView *parent)
+{
+    QScopedPointer<QQuickView> view(new QQuickView (0));
+    view->setTransientParent(parent);
+    host->registerWindow (view.data(), Maliit::PositionOverlay);
+    makeQuickViewTransparent(view.data());
+
+    return view.take ();
+}
+
+const QString g_maliit_keyboard_qml(MALIIT_KEYBOARD_DATA_DIR "/maliit-keyboard.qml");
+const QString g_maliit_keyboard_extended_qml(MALIIT_KEYBOARD_DATA_DIR "/maliit-keyboard-extended.qml");
+const QString g_maliit_magnifier_qml(MALIIT_KEYBOARD_DATA_DIR "/maliit-magnifier.qml");
+
+
+class SurfacesPrivate
+{
+public:
+    QScopedPointer<QQuickView> surface;
+    QScopedPointer<QQuickView> extended_surface;
+    QScopedPointer<QQuickView> magnifier_surface;
+
+    explicit SurfacesPrivate(MAbstractInputMethodHost *host);
+};
+
+
+SurfacesPrivate::SurfacesPrivate(MAbstractInputMethodHost *host)
+    : surface(getSurface(host))
+    , extended_surface(getOverlaySurface(host, surface.data()))
+    , magnifier_surface(getOverlaySurface(host, surface.data()))
+{
+    // TODO: Figure out whether two views can share one engine.
+    QQmlEngine *const engine(surface->engine());
+    engine->addImportPath(MALIIT_KEYBOARD_DATA_DIR);
+
+    QQmlEngine *const extended_engine(extended_surface->engine());
+    extended_engine->addImportPath(MALIIT_KEYBOARD_DATA_DIR);
+
+    QQmlEngine *const magnifier_engine(magnifier_surface->engine());
+    magnifier_engine->addImportPath(MALIIT_KEYBOARD_DATA_DIR);
+}
+
+
+Surfaces::Surfaces(MAbstractInputMethodHost *host,
+                   QObject *parent)
+    : View(host, parent)
+    , d_ptr(new SurfacesPrivate(host))
+{}
+
+
+Surfaces::~Surfaces()
+{}
+
+
+QQmlContext * Surfaces::context() const
+{
+    Q_D(const Surfaces);
+    return d->surface->engine()->rootContext();
+}
+
+
+QQmlContext * Surfaces::extendedKeysContext() const
+{
+    Q_D(const Surfaces);
+    return d->extended_surface->engine()->rootContext();
+}
+
+
+QQmlContext * Surfaces::magnifierContext() const
+{
+    Q_D(const Surfaces);
+    return d->magnifier_surface->engine()->rootContext();
+}
+
+
+void Surfaces::show()
+{
+    Q_D(Surfaces);
+    static bool is_initialized = false;
+
+    const QRect &rect = d->surface->screen()->availableGeometry();
+    const int width = d->surface->width();
+    const int height = d->surface->height();
+
+    d->surface->setGeometry(QRect(QPoint(rect.x() + (rect.width() - width) / 2,
+                                         rect.y() + rect.height() - height),
+                                  QSize(width, height)));
+
+
+    if (not is_initialized) {
+        d->surface->setSource(QUrl::fromLocalFile(g_maliit_keyboard_qml));
+        d->extended_surface->setSource(QUrl::fromLocalFile(g_maliit_keyboard_extended_qml));
+        d->magnifier_surface->setSource(QUrl::fromLocalFile(g_maliit_magnifier_qml));
+        is_initialized = true;
+    }
+
+    d->surface->show();
+    d->extended_surface->show();
+    d->magnifier_surface->show();
+}
+
+
+void Surfaces::hide()
+{
+    Q_D(Surfaces);
+    d->surface->hide();
+    d->extended_surface->hide();
+    d->magnifier_surface->hide();
+}
+
+
+void Surfaces::showExtendedKeys()
+{
+    Q_D(Surfaces);
+    d->extended_surface->show();
+}
+
+
+void Surfaces::hideExtendedKeys()
+{
+    Q_D(Surfaces);
+    d->extended_surface->hide();
+}
+
+
+void Surfaces::showMagnifier()
+{
+    Q_D(Surfaces);
+    d->magnifier_surface->show();
+}
+
+
+void Surfaces::hideMagnifier()
+{
+    Q_D(Surfaces);
+    d->magnifier_surface->hide();
+}
+
+
+void Surfaces::setWidth(int width)
+{
+    Q_D(Surfaces);
+    d->surface->setWidth(width);
+}
+
+
+void Surfaces::setHeight(int height)
+{
+    Q_D(Surfaces);
+    d->surface->setHeight(height);
+}
+
+
+void Surfaces::setOrigin(const QPoint &origin)
+{
+    Q_D(Surfaces);
+    d->surface->setPosition(origin);
+}
+
+
+void Surfaces::setExtendedKeysWidth(int width)
+{
+    Q_D(Surfaces);
+    d->extended_surface->setWidth(width);
+}
+
+
+void Surfaces::setExtendedKeysHeight(int height)
+{
+    Q_D(Surfaces);
+    d->extended_surface->setHeight(height);
+}
+
+
+void Surfaces::setExtendedKeysOrigin(const QPoint &origin)
+{
+    Q_D(Surfaces);
+    d->extended_surface->setPosition(d->surface->position() + origin);
+}
+
+
+void Surfaces::setMagnifierWidth(int width)
+{
+    Q_D(Surfaces);
+    d->magnifier_surface->setWidth(width);
+}
+
+
+void Surfaces::setMagnifierHeight(int height)
+{
+    Q_D(Surfaces);
+    d->magnifier_surface->setHeight(height);
+}
+
+
+void Surfaces::setMagnifierOrigin(const QPoint &origin)
+{
+    Q_D(Surfaces);
+    d->magnifier_surface->setPosition(d->surface->position() + origin);
+}
+
+
+} // namespace MaliitKeyboard

--- a/maliit-keyboard/plugin/surfaces.h
+++ b/maliit-keyboard/plugin/surfaces.h
@@ -1,0 +1,84 @@
+/*
+ * This file is part of Maliit Plugins
+ *
+ * Copyright (C) 2013 Michael Hasselmann
+ *
+ * Contact: maliit-discuss@lists.maliit.org
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef MALIIT_KEYBOARD_SURFACES_H
+#define MALIIT_KEYBOARD_SURFACES_H
+
+#include "view.h"
+
+namespace MaliitKeyboard {
+
+class SurfacesPrivate;
+
+class Surfaces
+    : public View
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(Surfaces)
+    Q_DECLARE_PRIVATE(Surfaces)
+
+public:
+    explicit Surfaces(MAbstractInputMethodHost *host,
+                      QObject *parent = 0);
+    virtual ~Surfaces();
+
+    QQmlContext * context() const;
+    QQmlContext * extendedKeysContext() const;
+    QQmlContext * magnifierContext() const;
+
+    void show();
+    void hide();
+
+    void showExtendedKeys();
+    void hideExtendedKeys();
+
+    void showMagnifier();
+    void hideMagnifier();
+
+    void setWidth(int width);
+    void setHeight(int height);
+    void setOrigin(const QPoint &origin);
+
+    void setExtendedKeysWidth(int width);
+    void setExtendedKeysHeight(int height);
+    void setExtendedKeysOrigin(const QPoint &origin);
+
+    void setMagnifierWidth(int width);
+    void setMagnifierHeight(int height);
+    void setMagnifierOrigin(const QPoint &origin);
+
+private:
+    const QScopedPointer<SurfacesPrivate> d_ptr;
+};
+
+} // namespace MaliitKeyboard
+
+#endif // MALIIT_KEYBOARD_SURFACES_H

--- a/maliit-keyboard/plugin/view.cpp
+++ b/maliit-keyboard/plugin/view.cpp
@@ -1,0 +1,167 @@
+/*
+ * This file is part of Maliit Plugins
+ *
+ * Copyright (C) 2013 Michael Hasselmann
+ *
+ * Contact: maliit-discuss@lists.maliit.org
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "view.h"
+
+namespace MaliitKeyboard {
+//! \class View
+//! \brief A view abstraction to handle platform-specific keyboard representations.
+//!
+//! On X11, we want to handle the view differently as for instance on Wayland.
+//! The latter allows usage of subsurfaces, whereas the former doesn't work too
+//! well with multiple property-driven views:
+//!   X11 expects property changes to take place in a certain order and cannot
+//! cope with rapid changes to XWindows at all (for instance, window placement
+//! or window visibility).
+//!   The Surfaces class handles multiple surfaces and should closely match
+//! Wayland's surface handling (including sub-surfaces). The Canvas class on
+//! the other hand represents one drawable area and targets X11. Therefore, it
+//! contains of a single QQuickView with enough space on top of the main
+//! keyboard area to also draw extended keys and the key magnifier.
+
+class ViewPrivate
+{};
+
+
+View::View(MAbstractInputMethodHost *host,
+           QObject *parent)
+    : QObject(parent)
+{
+    Q_UNUSED(host)
+}
+
+
+View::~View()
+{}
+
+
+//! \brief Returns primary QML context.
+//!
+//! Should never return null.
+QQmlContext * View::context() const
+{
+    return 0;
+}
+
+
+//! \brief Returns a secondary QML context.
+//!
+//! Can return null, in which case the primary QML context shall be used.
+//! See context().
+QQmlContext * View::extendedKeysContext() const
+{
+    return 0;
+}
+
+
+//! \brief Returns a secondary QML context.
+//!
+//! Can return null, in which case the primary QML context shall be used.
+//! See context().
+QQmlContext * View::magnifierContext() const
+{
+    return 0;
+}
+
+
+//! \brief Shows the primary view.
+//!
+//! Propagates to secondary views.
+void View::show() {}
+
+
+//! \brief Hides the primary view.
+//!
+//! Propagates to secondary views.
+void View::hide() {}
+
+
+//! \brief Shows secondary view for extended keys.
+//!
+//! Transient to primary view.
+void View::showExtendedKeys() {}
+
+
+//! \brief Hides secondary view for extended keys.
+//!
+//! Transient to primary view.
+void hideExtendedKeys() {}
+
+
+//! \brief Shows secondary view for magnifier.
+//!
+//! Transient to primary view.
+void View::showMagnifier() {}
+
+
+//! \brief Hides secondary view for magnifier.
+//!
+//! Transient to primary view.
+void View::hideMagnifier() {}
+
+
+//! \brief Sets width of primary view.
+void View::setWidth(int width) {Q_UNUSED(width)}
+
+
+//! \brief Sets height of primary view.
+void View::setHeight(int height) {Q_UNUSED(height)}
+
+
+//! \brief Sets origin of primary view.
+void View::setOrigin(const QPoint &origin) {Q_UNUSED(origin)}
+
+
+//! \brief Sets width of secondary view for extended keys.
+void View::setExtendedKeysWidth(int width) {Q_UNUSED(width)}
+
+
+//! \brief Sets height of secondary view for extended keys.
+void View::setExtendedKeysHeight(int height) {Q_UNUSED(height)}
+
+
+//! \brief Sets origin of secondary view for extended keys.
+void View::setExtendedKeysOrigin(const QPoint &origin) {Q_UNUSED(origin)};
+
+
+//! \brief Sets width of secondary view for magnifier.
+void View::setMagnifierWidth(int width) {Q_UNUSED(width)}
+
+
+//! \brief Sets height of secondary view for magnifier.
+void View::setMagnifierHeight(int height) {Q_UNUSED(height)}
+
+
+//! \brief Sets origin of secondary view for magnifier.
+void View::setMagnifierOrigin(const QPoint &origin) {Q_UNUSED(origin)}
+
+
+} // namespace MaliitKeyboard

--- a/maliit-keyboard/plugin/view.h
+++ b/maliit-keyboard/plugin/view.h
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Maliit Plugins
+ *
+ * Copyright (C) 2013 Michael Hasselmann
+ *
+ * Contact: maliit-discuss@lists.maliit.org
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef MALIIT_KEYBOARD_VIEW_H
+#define MALIIT_KEYBOARD_VIEW_H
+
+#include <maliit/plugins/abstractinputmethodhost.h>
+#include <QtCore>
+#include <QtQuick>
+
+namespace MaliitKeyboard {
+
+class View
+    : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(View)
+
+public:
+    explicit View(MAbstractInputMethodHost *host,
+                  QObject *parent = 0);
+    virtual ~View() = 0;
+
+    virtual QQmlContext * context() const = 0;
+    virtual QQmlContext * extendedKeysContext() const = 0;
+    virtual QQmlContext * magnifierContext() const = 0;
+
+    virtual void show() = 0;
+    virtual void hide() = 0;
+
+    virtual void showExtendedKeys() = 0;
+    virtual void hideExtendedKeys() = 0;
+
+    virtual void showMagnifier() = 0;
+    virtual void hideMagnifier() = 0;
+
+    virtual void setWidth(int width) = 0;
+    virtual void setHeight(int height) = 0;
+    virtual void setOrigin(const QPoint &origin) = 0;
+
+    virtual void setExtendedKeysWidth(int width) = 0;
+    virtual void setExtendedKeysHeight(int height) = 0;
+    virtual void setExtendedKeysOrigin(const QPoint &origin) = 0;
+
+    virtual void setMagnifierWidth(int width) = 0;
+    virtual void setMagnifierHeight(int height) = 0;
+    virtual void setMagnifierOrigin(const QPoint &origin) = 0;
+};
+
+} // namespace MaliitKeyboard
+
+#endif // MALIIT_KEYBOARD_VIEW_H


### PR DESCRIPTION
The new interface allows platform-dependent view implementations. On X11, we
want to handle the view differently as for instance on Wayland. The latter
allows usage of subsurfaces, whereas the former doesn't work too well with
multiple property-driven views:
  X11 expects property changes to take place in a certain order and cannot cope
with rapid changes to XWindows at all (for instance, window placement or window
visibility).
  The Surfaces class handles multiple surfaces and should closely match
Wayland's surface handling (including sub-surfaces). The Canvas class on the
other hand represents one drawable area and targets X11. Therefore, it contains
of a single QQuickView with enough space on top of the main keyboard area to
also draw extended keys and the key magnifier.
